### PR TITLE
Update yosys urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ License: MIT
 ### Yosys
 Yosys is a framework for Verilog RTL synthesis. It currently has extensive Verilog-2005 support and provides a basic set of synthesis algorithms for various application domains.
 
-Homepage: https://yosyshq.net/yosys/
-Github repository: https://github.com/YosysHQ/yosys
+Homepage: https://yosyshq.net/yosys/  
+Github repository: https://github.com/YosysHQ/yosys  
 
 License: ISC
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ License: MIT
 ### Yosys
 Yosys is a framework for Verilog RTL synthesis. It currently has extensive Verilog-2005 support and provides a basic set of synthesis algorithms for various application domains.
 
-Homepage: http://www.clifford.at/yosys/
+Homepage: https://yosyshq.net/yosys/
+Github repository: https://github.com/YosysHQ/yosys
 
 License: ISC
 


### PR DESCRIPTION
Yosys url at `clifford.at` was parked, updated to point at github repo and project url from github repo.